### PR TITLE
Added Sweet Alert shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# Ember-cli-sweet-alert
+# ember-cli-sweet-alert
 
-This README outlines the details of collaborating on this Ember addon.
+Adds [Sweet Alert](http://t4t5.github.io/sweetalert) plugin to Ember applications.
 
 ## Installation
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
+```bash
+ember install ember-cli-sweet-alert
+```
+
+## Usage
+
+```javascript
+import swal from 'sweetalert'
+
+swal("Here's a message!")
+
+```
 
 ## Running
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ module.exports = {
       production: app.bowerDirectory + '/sweetalert/dist/sweetalert.min.js'
     });
 
-    app.import(this.treePaths.vendor + '/sweet-alert-shim.js');
+    app.import(this.treePaths.vendor + '/shim.js');
   },
 };

--- a/index.js
+++ b/index.js
@@ -3,8 +3,17 @@
 
 module.exports = {
   name: 'ember-cli-sweet-alert',
-  included: function (app) {
-    app.import(app.bowerDirectory + "/sweetalert/dist/sweetalert.min.js");
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
     app.import(app.bowerDirectory + "/sweetalert/dist/sweetalert.css");
-  }
+
+    app.import({
+      development: app.bowerDirectory + '/sweetalert/dist/sweetalert-dev.js',
+      production: app.bowerDirectory + '/sweetalert/dist/sweetalert.min.js'
+    });
+
+    app.import(this.treePaths.vendor + '/sweet-alert-shim.js');
+  },
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/bbooth/ember-cli-sweet-alerts.git",
+  "repository": "https://github.com/bbooth/ember-cli-sweet-alert.git",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/vendor/shim.js
+++ b/vendor/shim.js
@@ -1,11 +1,14 @@
 (function() {
+	
 	/* globals define, swal */
-	define('swal', [], function() {
-		'use strict';
+	['swal', 'sweetalert'].forEach(function(name) {
+		define(name, [], function() {
+			'use strict';
 
-		return {
-			default: swal
-		};
+			return {
+				default: swal
+			};
+		});
 	});
 
 })();

--- a/vendor/shim.js
+++ b/vendor/shim.js
@@ -1,0 +1,11 @@
+(function() {
+	/* globals define, swal */
+	define('swal', [], function() {
+		'use strict';
+
+		return {
+			default: swal
+		};
+	});
+
+})();


### PR DESCRIPTION
Hi @bbooth 

if you do not mind, I've added an Ember CLI shim for Sweet Alert so that you can import the `swal` function in your code. As well `README.md` file has been updated with installation and usage instructions.

Regards,
Vladimir
